### PR TITLE
Add preval file support

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -24,7 +24,11 @@
       "name": "Matt Phillips",
       "avatar_url": "https://avatars3.githubusercontent.com/u/5610087?v=3",
       "profile": "http://mattphillips.io",
-      "contributions": []
+      "contributions": [
+        "code",
+        "doc",
+        "test"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const x = {
 
 There's also `preval.require('./something')` and
 `import x from /* preval */ './something'` (which can both take some arguments)
-or add `// @preval` comment at the of a file.
+or add `// @preval` comment at the top of a file.
 
 See more below.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ const x = {
 ```
 
 There's also `preval.require('./something')` and
-`import x from /* preval */ './something'` (which can both take some arguments).
+`import x from /* preval */ './something'` (which can both take some arguments)
+or add `// @preval` comment at the of a file.
 
 See more below.
 
@@ -182,6 +183,33 @@ const fileLastModifiedDate = preval.require('./get-last-modified-date', '../../s
 
 ```javascript
 const fileLastModifiedDate = '2017-07-04'
+```
+
+### preval file comment (`// @preval`)
+
+Using the preval file comment will update a whole file to be evaluated down to an export.
+
+Whereas the above usages (assignment/import/require) will only preval the scope of the assignment or file being imported.
+
+**Before**:
+
+```javascript
+// @preval
+
+const id = require("./path/identity")
+const one = require("./path/one")
+
+const compose = (...fns) => fns.reduce((f, g) => a => f(g(a)))
+const double = a => a * 2
+const square = a => a * a
+
+module.exports = compose(square, id, double)(one)
+```
+
+**After**:
+
+```javascript
+module.exports = 4
 ```
 
 ## Configure with Babel

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ here!
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/babel-plugin-preval/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/babel-plugin-preval/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/babel-plugin-preval/commits?author=kentcdodds "Tests") | [<img src="https://avatars3.githubusercontent.com/u/5610087?v=3" width="100px;"/><br /><sub>Matt Phillips</sub>](http://mattphillips.io)<br /> |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/babel-plugin-preval/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/babel-plugin-preval/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/babel-plugin-preval/commits?author=kentcdodds "Tests") | [<img src="https://avatars3.githubusercontent.com/u/5610087?v=3" width="100px;"/><br /><sub>Matt Phillips</sub>](http://mattphillips.io)<br />[💻](https://github.com/kentcdodds/babel-plugin-preval/commits?author=mattphillips "Code") [📖](https://github.com/kentcdodds/babel-plugin-preval/commits?author=mattphillips "Documentation") [⚠️](https://github.com/kentcdodds/babel-plugin-preval/commits?author=mattphillips "Tests") |
 | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -201,3 +201,156 @@ const x = preval.require("./fixtures/compute-one", "should not be here...")
 Error: <PROJECT_ROOT>/src/__tests__/index.js: \`preval.require\`-ed module (./fixtures/compute-one) cannot accept arguments because it does not export a function. You passed the arguments: should not be here...
 
 `;
+
+exports[`21. preval 1`] = `
+
+// @preval
+module.exports = 1 + 2 - 1 - 1
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// this file was prevaled
+module.exports = 1;
+
+`;
+
+exports[`22. preval 1`] = `
+
+// @preval
+const ten = 9 + 1
+module.exports = ten * 5
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// this file was prevaled
+module.exports = 50;
+
+`;
+
+exports[`23. preval 1`] = `
+
+// @flow
+// @preval
+module.exports = 1 + 2 - 1 - 1
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// @flow
+// this file was prevaled
+module.exports = 1;
+
+`;
+
+exports[`24. preval 1`] = `
+
+// @preval
+// @flow
+module.exports = 1 + 2 - 1 - 1
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// this file was prevaled
+// @flow
+module.exports = 1;
+
+`;
+
+exports[`25. preval 1`] = `
+
+// @preval
+const name = 'Bob Hope'
+const splitter = str => str.split(' ')
+module.exports = splitter(name)
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// this file was prevaled
+module.exports = ["Bob", "Hope"];
+
+`;
+
+exports[`26. preval 1`] = `
+
+// @preval
+const name = 'Bob Hope'
+const splitter = str => str.split(' ')
+const [first, last] = splitter(name)
+module.exports = {first, last}
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// this file was prevaled
+module.exports = { "first": "Bob", "last": "Hope" };
+
+`;
+
+exports[`27. preval 1`] = `
+
+// @preval
+module.exports = require("./fixtures/compute-one")
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// this file was prevaled
+module.exports = 1;
+
+`;
+
+exports[`28. preval 1`] = `
+
+// @preval
+module.exports = require("./fixtures/identity")('hello world')
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// this file was prevaled
+module.exports = "hello world";
+
+`;
+
+exports[`29. preval 1`] = `
+
+// @preval
+const id = require("./fixtures/identity")
+const computeOne = require("./fixtures/compute-one")
+
+const compose = (...fns) => a => fns.reduceRight((acc, fn) => fn(acc), a)
+const double = a => a * 2
+const square = a => a * a
+
+module.exports = compose(square, id, double)(computeOne)
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// this file was prevaled
+module.exports = 4;
+
+`;
+
+exports[`30. preval 1`] = `
+
+// @preval
+const fs = require('fs')
+module.exports = fs.readFileSync(require.resolve('./fixtures/fixture1.md'), 'utf8')
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// this file was prevaled
+module.exports = "# fixture\\n\\nThis is some file thing...\\n";
+
+`;
+
+exports[`31. preval 1`] = `
+
+// @preval
+function fib(x) {
+  return x <= 1 ? x : fib(x - 1) + fib(x - 2);
+}
+module.exports = fib(10)
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// this file was prevaled
+module.exports = 55;
+
+`;

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -314,7 +314,8 @@ exports[`29. preval 1`] = `
 const id = require("./fixtures/identity")
 const computeOne = require("./fixtures/compute-one")
 
-const compose = (...fns) => a => fns.reduceRight((acc, fn) => fn(acc), a)
+const compose = (...fns) => fns.reduce((f, g) => a => f(g(a)))
+
 const double = a => a * 2
 const square = a => a * a
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -102,14 +102,12 @@ pluginTester({
       babelOptions: {filename: __filename},
     },
     {
-      snapshot: true,
       code: `
         // @preval
         module.exports = 1 + 2 - 1 - 1
       `,
     },
     {
-      snapshot: true,
       code: `
         // @preval
         const ten = 9 + 1
@@ -117,7 +115,6 @@ pluginTester({
       `,
     },
     {
-      snapshot: true,
       code: `
         // @flow
         // @preval
@@ -125,7 +122,6 @@ pluginTester({
       `,
     },
     {
-      snapshot: true,
       code: `
         // @preval
         // @flow
@@ -133,7 +129,6 @@ pluginTester({
       `,
     },
     {
-      snapshot: true,
       code: `
         // @preval
         const name = 'Bob Hope'
@@ -142,7 +137,6 @@ pluginTester({
       `,
     },
     {
-      snapshot: true,
       code: `
         // @preval
         const name = 'Bob Hope'
@@ -152,7 +146,6 @@ pluginTester({
       `,
     },
     {
-      snapshot: true,
       babelOptions: {filename: __filename},
       code: `
         // @preval
@@ -160,7 +153,6 @@ pluginTester({
       `,
     },
     {
-      snapshot: true,
       babelOptions: {filename: __filename},
       code: `
         // @preval
@@ -168,7 +160,6 @@ pluginTester({
       `,
     },
     {
-      snapshot: true,
       babelOptions: {filename: __filename},
       code: `
         // @preval
@@ -183,7 +174,6 @@ pluginTester({
       `,
     },
     {
-      snapshot: true,
       babelOptions: {filename: __filename},
       code: `
         // @preval
@@ -192,7 +182,6 @@ pluginTester({
       `,
     },
     {
-      snapshot: true,
       babelOptions: {filename: __filename},
       code: `
         // @preval

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -166,7 +166,8 @@ pluginTester({
         const id = require("./fixtures/identity")
         const computeOne = require("./fixtures/compute-one")
 
-        const compose = (...fns) => a => fns.reduceRight((acc, fn) => fn(acc), a)
+        const compose = (...fns) => fns.reduce((f, g) => a => f(g(a)))
+
         const double = a => a * 2
         const square = a => a * a
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -102,15 +102,104 @@ pluginTester({
       babelOptions: {filename: __filename},
     },
     {
-      skip: true,
-      snapshot: false,
+      snapshot: true,
       code: `
         // @preval
         module.exports = 1 + 2 - 1 - 1
       `,
-      output: `
-        // this file was prevaled
-        module.exports = 1;
+    },
+    {
+      snapshot: true,
+      code: `
+        // @preval
+        const ten = 9 + 1
+        module.exports = ten * 5
+      `,
+    },
+    {
+      snapshot: true,
+      code: `
+        // @flow
+        // @preval
+        module.exports = 1 + 2 - 1 - 1
+      `,
+    },
+    {
+      snapshot: true,
+      code: `
+        // @preval
+        // @flow
+        module.exports = 1 + 2 - 1 - 1
+      `,
+    },
+    {
+      snapshot: true,
+      code: `
+        // @preval
+        const name = 'Bob Hope'
+        const splitter = str => str.split(' ')
+        module.exports = splitter(name)
+      `,
+    },
+    {
+      snapshot: true,
+      code: `
+        // @preval
+        const name = 'Bob Hope'
+        const splitter = str => str.split(' ')
+        const [first, last] = splitter(name)
+        module.exports = {first, last}
+      `,
+    },
+    {
+      snapshot: true,
+      babelOptions: {filename: __filename},
+      code: `
+        // @preval
+        module.exports = require("./fixtures/compute-one")
+      `,
+    },
+    {
+      snapshot: true,
+      babelOptions: {filename: __filename},
+      code: `
+        // @preval
+        module.exports = require("./fixtures/identity")('hello world')
+      `,
+    },
+    {
+      snapshot: true,
+      babelOptions: {filename: __filename},
+      code: `
+        // @preval
+        const id = require("./fixtures/identity")
+        const computeOne = require("./fixtures/compute-one")
+
+        const compose = (...fns) => a => fns.reduceRight((acc, fn) => fn(acc), a)
+        const double = a => a * 2
+        const square = a => a * a
+
+        module.exports = compose(square, id, double)(computeOne)
+      `,
+    },
+    {
+      snapshot: true,
+      babelOptions: {filename: __filename},
+      code: `
+        // @preval
+        const fs = require('fs')
+        module.exports = fs.readFileSync(require.resolve('./fixtures/fixture1.md'), 'utf8')
+      `,
+    },
+    {
+      snapshot: true,
+      babelOptions: {filename: __filename},
+      code: `
+        // @preval
+        function fib(x) {
+          return x <= 1 ? x : fib(x - 1) + fib(x - 2);
+        }
+        module.exports = fib(10)
       `,
     },
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,11 @@
 const p = require('path')
 const babylon = require('babylon')
 const requireFromString = require('require-from-string')
-const babel = require('babel-core')
 // const printAST = require('ast-pretty-print')
 
 module.exports = prevalPlugin
 
-function prevalPlugin({types: t, template, transform}) {
+function prevalPlugin({types: t, template, transform, transformFromAst}) {
   const assignmentBuilder = template('const NAME = VALUE')
   return {
     name: 'preval',
@@ -21,10 +20,10 @@ function prevalPlugin({types: t, template, transform}) {
 
         comments.find(isPrevalComment).value = ' this file was prevaled'
 
-        const {code: string} = babel.transformFromAst(path.node)
+        const {code: string} = transformFromAst(path.node)
         const replacement = getReplacement({string, filename})
 
-        const moduleExport = Object.assign(
+        const moduleExports = Object.assign(
           {},
           t.expressionStatement(
             t.assignmentExpression(
@@ -39,7 +38,7 @@ function prevalPlugin({types: t, template, transform}) {
           {leadingComments: comments},
         )
 
-        path.replaceWith(t.program([moduleExport]))
+        path.replaceWith(t.program([moduleExports]))
       },
       TaggedTemplateExpression(path, {file: {opts: {filename}}}) {
         const isPreval = path.node.tag.name === 'preval'


### PR DESCRIPTION
Hey I'm not sure if this is the best approach to solve the problem but it seems to be working 😄 

As you said in the issue there is probably more edge cases that may need covering.

**What**:

Add support for prevaling a file with `// @preval` comment.

**Why**:

See: https://github.com/kentcdodds/babel-plugin-preval/issues/2

**How**:

 - `Program` type is used to hook into the first node in the body and check if it has any `leadingComments`. 
 - If the comments contain a `// @preval` then the AST is parsed into code and then executed.
 - A new `module.exports` expression is created and returns the result of running the code.
 - This expression is set to the programs body alongside any leading comments and the custom `this file was prevaled` comment.

**Todo**
 - [x] Update docs with examples
 - [x] Confirm printing of `// this file was prevaled` comment

<!-- feel free to add additional comments -->
