### PR TITLE
fix(plugin): Safe access to leadingComments

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -210,6 +210,16 @@ pluginTester({
         module.exports = smth.UNDEFINED;
       `,
     },
+    {
+      snapshot: false,
+      code: '// @preval',
+    },
+    {
+      snapshot: false,
+      code: `
+        // @preval
+        /* comment */`,
+    },
 
     // please add a file for your use-case
     // in the `fixtures` directory and make

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,8 @@ function prevalPlugin({types: t, template, transformFromAst}) {
     name: 'preval',
     visitor: {
       Program(path, {file: {opts: {filename}}}) {
-        const comments = path.node.body[0].leadingComments || []
+        const firstNode = path.node.body[0] || {}
+        const comments = firstNode.leadingComments || []
         const isPreval = comments.some(isPrevalComment)
 
         if (!isPreval) {
@@ -47,7 +48,9 @@ function prevalPlugin({types: t, template, transformFromAst}) {
         }
         const string = path.get('quasi').evaluate().value
         if (!string) {
-          throw new Error('Unable to determine the value of your preval string')
+          throw new Error(
+            'Unable to determine the value of your preval string',
+          )
         }
         const replacement = getReplacement({string, filename})
         path.replaceWith(replacement)
@@ -168,7 +171,7 @@ function looksLike(a, b) {
 
 function isPrimitive(val) {
   // eslint-disable-next-line
-  return val == null || /^[sbn]/.test(typeof val)
+  return val == null || /^[sbn]/.test(typeof val);
 }
 
 /*


### PR DESCRIPTION
**What**:

Prevents error on preval when dealing with empty files

**Why**:

`path.node.body` can be undefined, these changes make sure we safely access `leadingComments` property.

**How**:

Your suggested code changes and test cases

Prettier added a couple additional changes as part of the precommit hook, I wasn't sure if you wanted to keep these in or not

Closes https://github.com/kentcdodds/babel-plugin-preval/issues/20