### PR TITLE
Do not load root .babelrc

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,10 +27,10 @@ function prevalPlugin(babel) {
 
         comments.find(isPrevalComment).value = ' this file was prevaled'
 
-        /* istanbul ignore next (babel 6 vs babel 7 check) */
         const {code: string} = transformFromAst(
           path.node,
           null,
+          /* istanbul ignore next (babel 6 vs babel 7 check) */
           /^6\./.test(babel.version)
             ? {}
             : {

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ function prevalPlugin(babel) {
 
         comments.find(isPrevalComment).value = ' this file was prevaled'
 
+        /* istanbul ignore next (babel 6 vs babel 7 check) */
         const {code: string} = transformFromAst(
           path.node,
           null,

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,16 @@ function prevalPlugin(babel) {
 
         comments.find(isPrevalComment).value = ' this file was prevaled'
 
-        const {code: string} = transformFromAst(path.node)
+        const {code: string} = transformFromAst(
+          path.node,
+          null,
+          /^6\./.test(babel.version)
+            ? {}
+            : {
+                babelrc: false,
+                configFile: false,
+              },
+        )
         const replacement = getReplacement({string, fileOpts, babel})
 
         const moduleExports = Object.assign(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Do not load root `.babelrc` and `babel.config.js` in the run of `transformFromAST` in Babel v7.

<!-- Why are these changes necessary? -->

**Why**: Without this change the Babel plugin will be loaded twice. (ref https://github.com/babel/babel/pull/7911)

<!-- How were these changes implemented? -->

**How**: Set `babelrc: false` and `configFile: false`.

<!-- feel free to add additional comments -->
