### PR TITLE
Add support for evaluating basic typescript

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,10 @@ function prevalPlugin(babel) {
           /^6\./.test(babel.version)
             ? {}
             : {
+                filename: fileOpts.filename,
+                plugins: fileOpts.filename.match(/\.tsx?$/)
+                  ? ["@babel/plugin-transform-typescript"]
+                  : [],
                 babelrc: false,
                 configFile: false,
               },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Allows preval to parse typescript (and potentially any dialect supported by babel with some extra work)

<!-- Why are these changes necessary? -->

**Why**: Preval currently chokes on typescript. 

This PR serves as a *proof-of-concept* to show that a TS file can be transformed into plain JS before being handed off the the `require-from-string` helper.

This could be generalized with a more extensive set of transformers, or potentially even a babel option for the plugin to allow an arbitrary set of extra plugins.

<!-- How were these changes implemented? -->

**How**: Check for typescript files when parsing a `@preval` tagged file, and optionally parse it with the typescript transformer enabled. 

Note, this example only handled the file comment approach, since that code already used babel for parsing the input file. Expanding this it to support the other three approaches would require some changes to use babel handlers such as [transformFileSync](https://babeljs.io/docs/en/babel-core#transformfilesync) or [transformSync](https://babeljs.io/docs/en/babel-core#transformsync)

<!-- feel free to add additional comments -->
