### PR TITLE
#82 but with babel options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ See more below.
   - [import comment](#import-comment)
   - [preval.require](#prevalrequire)
   - [preval file comment (`// @preval`)](#preval-file-comment--preval)
+    - [Configuring babel parser for preval file](#configuring-babel-parser-for-files-using-preval-file-comment)
 - [Exporting a function](#exporting-a-function)
 - [Configure with Babel](#configure-with-babel)
   - [Via `.babelrc` (Recommended)](#via-babelrc-recommended)

--- a/README.md
+++ b/README.md
@@ -253,6 +253,57 @@ module.exports = compose(square, id, double)(one)
 module.exports = 4
 ```
 
+#### Configuring babel parser for files using preval file comment
+
+When using the preval file comment above, it's possible to configure the babel
+parser used to interpret this file using babel options.
+
+For example, if the `// @preval` file is written in typescript the following
+babel configuration would allow the preval plugin to successfully parse the file
+when using node version 14+.
+
+```javascript
+{
+  plugins: [
+    [
+      'preval',
+      {
+        prevalBabelOptions: {
+          plugins: [
+            '@babel/plugin-transform-typescript',
+            '@babel/plugin-transform-modules-commonjs',
+          ],
+        },
+      },
+    ],
+  ]
+}
+```
+
+This would then allow the following file to preval correctly:
+
+```ts
+// @preval
+
+import planetArray, { PlanetEnum } from "./examplePlanetList"
+import { getPlanetRadius } from "exampleGetPlanetRadiusLib"
+
+type PlanetRadiusDataType: Array<{ planet: PlanetEnum, radius: number }>
+const data: PlanetRadiusDataType = planetArray.map((planet: PlanetEnum) => {
+  return {
+    planet,
+    radius: getPlanetRadius(planet)
+  }
+})
+
+export default data
+```
+
+Note: The `prevalBabelOptions` accepts all options accepted by babel, similar to
+the `.babelrc` file.
+
+See [here](https://babeljs.io/docs/en/options) for a list of valid options.
+
 ## Exporting a function
 
 If you export a function from a module that you're prevaling (whether using
@@ -459,6 +510,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">=10",
     "npm": ">=6"
   },
-  "main": "dist/index.js",
+  "main": "src/index.js",
   "scripts": {
     "build": "kcd-scripts build",
     "lint": "kcd-scripts lint",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">=10",
     "npm": ">=6"
   },
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "kcd-scripts build",
     "lint": "kcd-scripts lint",

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -31,7 +31,8 @@ const x = preval.require("../__tests__/fixtures/nested/absolute-path")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-const x = '<PROJECT_ROOT>/src/__tests__/index.js'
+const x =
+  '<PROJECT_ROOT>/src/__tests__/index.js'
 
 
 `;

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -31,8 +31,7 @@ const x = preval.require("../__tests__/fixtures/nested/absolute-path")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-const x =
-  '<PROJECT_ROOT>/src/__tests__/index.js'
+const x = '<PROJECT_ROOT>/src/__tests__/index.js'
 
 
 `;
@@ -94,6 +93,17 @@ const x = 1
 
 `;
 
+exports[`preval import comment with babel options: import comment with babel options 1`] = `
+
+import x from /* preval */ "./fixtures/compute-one.js"
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const x = 1
+
+
+`;
+
 exports[`preval import comment: import comment 1`] = `
 
 import x from /* preval */ "./fixtures/compute-one.js"
@@ -137,6 +147,24 @@ import x from /* preval("string argument") */ "./fixtures/identity.js"
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const x = 'string argument'
+
+
+`;
+
+exports[`preval require functions with babel options: require functions with babel options 1`] = `
+
+const x = preval.require("./fixtures/multiple-functions")
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const x = {
+  a: function a() {
+    return 'a'
+  },
+  b: function b() {
+    return 'b'
+  },
+}
 
 
 `;
@@ -190,6 +218,19 @@ Error: <PROJECT_ROOT>/src/__tests__/index.js: preval cannot determine the value 
 
 `;
 
+exports[`preval simple comment with babel options: simple comment with babel options 1`] = `
+
+// @preval
+module.exports = 1 + 2 - 1 - 1
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+// this file was prevaled
+module.exports = 1
+
+
+`;
+
 exports[`preval simple comment: simple comment 1`] = `
 
 // @preval
@@ -220,6 +261,17 @@ const y = {
     return 'booyah'
   },
 }
+
+
+`;
+
+exports[`preval simple number with babel options: simple number with babel options 1`] = `
+
+const x = preval\`module.exports = 1\`
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const x = 1
 
 
 `;

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -31,8 +31,7 @@ const x = preval.require("../__tests__/fixtures/nested/absolute-path")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-const x =
-  '<PROJECT_ROOT>/src/__tests__/index.js'
+const x = '<PROJECT_ROOT>/src/__tests__/index.js'
 
 
 `;

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -107,8 +107,17 @@ pluginTester({
 pluginTester({
   plugin,
   snapshot: true,
-  babelOptions: {filename: __filename, prevalBabelOptions: {}},
+  babelOptions: {filename: __filename},
+  pluginOptions: {prevalBabelOptions: {}},
   tests: {
-    'simple number': 'const x = preval`module.exports = 1`',
+    'simple number with babel options': 'const x = preval`module.exports = 1`',
+    'import comment with babel options':
+      'import x from /* preval */ "./fixtures/compute-one.js"',
+    'require functions with babel options':
+      'const x = preval.require("./fixtures/multiple-functions")',
+    'simple comment with babel options': `
+      // @preval
+      module.exports = 1 + 2 - 1 - 1
+    `,
   },
 })

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -103,3 +103,12 @@ pluginTester({
     `,
   },
 })
+
+pluginTester({
+  plugin,
+  snapshot: true,
+  babelOptions: {filename: __filename, prevalBabelOptions: {}},
+  tests: {
+    'simple number': 'const x = preval`module.exports = 1`',
+  },
+})

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ function prevalPlugin(babel) {
             : {
                 filename: fileOpts.filename,
                 plugins: fileOpts.filename.match(/\.tsx?$/)
-                  ? ["@babel/plugin-transform-typescript"]
+                  ? ["@babel/plugin-transform-typescript", "@babel/plugin-transform-modules-commonjs"]
                   : [],
                 babelrc: false,
                 configFile: false,

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,10 @@ function prevalPlugin(babel) {
           /^6\./.test(babel.version)
             ? {}
             : {
+                filename: fileOpts.filename,
+                plugins: fileOpts.filename.match(/\.tsx?$/)
+                  ? ["@babel/plugin-transform-typescript"]
+                  : [],
                 babelrc: false,
                 configFile: false,
               },


### PR DESCRIPTION
Continuing from #82, with more generic handling...

**What**: Allows preval to parse typescript (and potentially any dialect supported by babel with some extra work)

<!-- Why are these changes necessary? -->

**Why**: Preval currently chokes on typescript. 

This PR serves as a *proof-of-concept* to show that a TS file can be transformed into plain JS before being handed off the the `require-from-string` helper.

This could be generalized with a more extensive set of transformers, or potentially even a babel option for the plugin to allow an arbitrary set of extra plugins.

<!-- How were these changes implemented? -->

**How**: Check for typescript files when parsing a `@preval` tagged file, and optionally parse it with the typescript transformer enabled. 

Note, this example only handled the file comment approach, since that code already used babel for parsing the input file. Expanding this it to support the other three approaches would require some changes to use babel handlers such as [transformFileSync](https://babeljs.io/docs/en/babel-core#transformfilesync) or [transformSync](https://babeljs.io/docs/en/babel-core#transformsync)

<!-- feel free to add additional comments -->
